### PR TITLE
Add missing Triton dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ This repository is the official implementation of [Tune-A-Video](https://arxiv.o
 ```shell
 pip install -r requirements.txt
 ```
+If you encounter `ModuleNotFoundError: No module named 'triton.ops'` when training, make sure
+to install the [Triton](https://github.com/openai/triton) package (required by
+`bitsandbytes`):
+```shell
+pip install triton==2.1.0
+```
 
 Installing [xformers](https://github.com/facebookresearch/xformers) is highly recommended for more efficiency and speed on GPUs. 
 To enable xformers, set `enable_xformers_memory_efficient_attention=True` (default).

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ omegaconf
 einops
 imageio
 ftfy
+triton==2.1.0


### PR DESCRIPTION
## Summary
- add Triton to requirements
- document troubleshooting for `triton.ops` errors in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff9c55bb48331b827b876643de7eb